### PR TITLE
Improve docs with emojis and cleanup

### DIFF
--- a/AGENTS-EXAMPLE-1.md
+++ b/AGENTS-EXAMPLE-1.md
@@ -1,4 +1,4 @@
-# AGENTS Example 1
+# AGENTS Example 1 ✨
 
 This example shows a minimal `AGENTS.md` configuration.
 
@@ -11,15 +11,15 @@ This example shows a minimal `AGENTS.md` configuration.
 This example demonstrates a simple set of instructions that could be placed in a
 project directory.
 
-## Code Style
+## Code Style 💅
 - Follow PEP8 formatting.
 - Limit lines to 100 characters.
 
-## Testing
+## Testing ✅
 - Run `pytest` after making changes.
 - If tests fail due to missing dependencies, add a note to the PR.
 
-## PR Message Guidelines
+## PR Message Guidelines 📋
 - Summarize key code changes.
 - Include a short section on test results.
 

--- a/AGENTS-EXAMPLE-2.md
+++ b/AGENTS-EXAMPLE-2.md
@@ -1,5 +1,5 @@
 
-# AGENTS Example 2
+# AGENTS Example 2 🌟
 
 This example demonstrates a more involved configuration.
 
@@ -9,19 +9,19 @@ This example demonstrates a more involved configuration.
 - Commit messages should reference an issue number, e.g., `Fix #12: short description`.
 - Summaries for pull requests must include a list of the commands executed.
 
-# Advanced AGENTS.md Example
+# Advanced AGENTS.md Example ✨
 
 This example showcases more complex instructions and placeholders.
 
-## Build Steps
+## Build Steps 🛠️
 - Run `make lint` to check code style.
 - Run `make test` to execute the test suite.
 
-## Fallback Behavior
+## Fallback Behavior ⚠️
 - If `make test` fails due to missing dependencies, include the disclaimer
   provided in the AGENTS guide in the PR.
 
-## PR Message Guidelines
+## PR Message Guidelines 📋
 - Begin the PR body with a one-sentence summary.
 - Provide a bullet list of major changes.
 - Attach test output or note why tests could not run.

--- a/AGENTS-EXAMPLE-3.md
+++ b/AGENTS-EXAMPLE-3.md
@@ -1,4 +1,4 @@
-# AGENTS Example 3
+# AGENTS Example 3 🚀
 
 This configuration focuses on message templates and Node-based tooling.
 

--- a/AGENTS-EXAMPLE-4.md
+++ b/AGENTS-EXAMPLE-4.md
@@ -1,4 +1,4 @@
-# AGENTS Example 4
+# AGENTS Example 4 🧪
 
 This example demonstrates environment setup and conditional behavior.
 

--- a/AGENTS-GUIDE.md
+++ b/AGENTS-GUIDE.md
@@ -1,80 +1,4 @@
-# CODEX Agents Guide
-
-This guide explains how to use `AGENTS.md` files with the CODEX
-system. An `AGENTS.md` file contains instructions that influence how
-CODEX behaves when modifying a repository. These instructions can cover
-coding conventions, testing steps, or even how pull request messages
-should look.
-
-## 1. Purpose
-
-The primary goal of an `AGENTS.md` file is to give repository-specific
-rules to the CODEX agent. It allows project maintainers to specify
-what checks the agent should run, how code should be formatted, or any
-other task that needs to occur automatically during an update.
-
-## 2. Placement and Scope
-
-`AGENTS.md` files can appear anywhere in a repository. The file affects
-the directory that contains it and all subdirectories. If multiple
-`AGENTS.md` files exist at different levels, the deepest one takes
-precedence for files under its directory.
-
-## 3. Format
-
-`AGENTS.md` is written in standard Markdown. You can organize
-instructions with headings, bullet lists, or code blocks. Keep the
-content clear and concise so the agent can interpret it easily.
-
-```
-# Example Layout
-- Use bullet points for step lists
-- Provide short explanations
-- Include commands in fenced code blocks
-```
-
-## 4. Standard Prompting Techniques
-
-Below are common ways to guide the agent using an `AGENTS.md` file:
-
-- **Testing**: List commands the agent should run after making changes.
-- **Formatting**: Specify formatting tools, such as `black` or
-  `prettier`, to enforce style rules.
-- **Commit Messages**: Describe how commit messages should be
-  structured, including any prefixes or maximum lengths.
-- **Pull Request Notes**: If special instructions are needed for pull
-  request summaries, include them here.
-
-## 5. Advanced Techniques
-
-For more complex workflows, you can provide additional details:
-
-- **Custom Scripts**: Instruct the agent to run project-specific
-  scripts. Example: `./scripts/update_docs.sh`.
-- **Environment Setup**: If tests require a setup step, explain the
-  necessary commands.
-- **Selective Behavior**: Mention when certain instructions should be
-  skipped or overridden, such as disabling tests for documentation-only
-  changes.
-- **Nested Rules**: Use separate `AGENTS.md` files in subdirectories to
-  override or extend behavior for specific parts of the project.
-- **Message Templates**: Define how commit messages or pull request
-  summaries should be structured.
-- **Error Handling**: Tell the agent what to do if a command fails, such
-  as noting that tests could not run due to environment limitations.
-
-## 6. Example Files
-
-The repository includes example files (`AGENTS-EXAMPLE-1.md` and
-`AGENTS-EXAMPLE-2.md`) that demonstrate how an `AGENTS.md` might look
-in practice. These samples showcase both basic and advanced features.
-Additional examples (`AGENTS-EXAMPLE-3.md` and `AGENTS-EXAMPLE-4.md`)
-highlight message templates, environment setup, and conditional rules.
-
-Use these examples as a starting point when creating your own
-`AGENTS.md` to guide CODEX in your projects.
-
-# AGENTS Guide for the CODEX System
+# AGENTS Guide for the CODEX System 🚀
 
 This document describes how to use `AGENTS.md` files to influence agent behavior
 within the CODEX repository. These files contain instructions that supplement
@@ -144,5 +68,5 @@ creates a pull request from this repository.
 - Combine `AGENTS.md` with continuous integration scripts for best results.
 
 This guide should help you craft your own `AGENTS.md` files to extend the
-functionality and quality of your CODEX projects.
+functionality and quality of your CODEX projects. ✅
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Welcome to CODEX, an empty repository that now serves as a new home.
 This repo can be a playground for experiments, tests, or any kind of
 project you might want to build. Feel free to expand it as needed.
 
+Check out `AGENTS-GUIDE.md` and the `AGENTS-EXAMPLE-*` files for tips on
+customizing the Codex agent. :sparkles:
+


### PR DESCRIPTION
## Summary
- clean up duplicated content in AGENTS-GUIDE
- add emoji markers to example AGENTS docs
- reference the docs in README

## Testing
- `python home.py`

------
https://chatgpt.com/codex/tasks/task_e_685721c06aa0832491c1d62683786a57