### PR TITLE
Introduce minimal Codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ project you might want to build. Feel free to expand it as needed.
 Check out `AGENTS-GUIDE.md` and the `AGENTS-EXAMPLE-*` files for tips on
 customizing the Codex agent. :sparkles:
 
+## Tools
+
+A minimal Python implementation of the Codex CLI lives in `codex_cli/`. It is inspired by the original [CODEX-CLI project](https://github.com/SYSTEMS-OPERATOR/CODEX-CLI) but greatly simplified.
+
+```bash
+pip install openai python-dotenv
+python -m codex_cli --help
+```

--- a/codex_cli/README.md
+++ b/codex_cli/README.md
@@ -1,0 +1,14 @@
+# Codex CLI
+
+A lightweight command line interface inspired by OpenAI's `codex` tool. This version focuses on simplicity and is implemented in Python.
+
+## Quickstart
+
+Install the optional dependencies and run the CLI with a prompt:
+
+```bash
+pip install openai python-dotenv
+python -m codex_cli "generate hello world in python"
+```
+
+Set your `OPENAI_API_KEY` environment variable or create a `.env` file with the variable defined. Use `--model` to target a specific model or `--dry-run` to print the prompt without contacting the API.

--- a/codex_cli/__init__.py
+++ b/codex_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Codex CLI package."""
+
+__all__ = ["main"]
+
+from .cli import main

--- a/codex_cli/__main__.py
+++ b/codex_cli/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/codex_cli/cli.py
+++ b/codex_cli/cli.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Minimal Codex command line interface."""
+
+import argparse
+import os
+from typing import List
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - dependency optional
+    load_dotenv = lambda: None
+
+try:
+    import openai
+except ImportError:  # pragma: no cover - openai optional
+    openai = None
+
+
+def _create_completion(prompt: str, model: str) -> str:
+    if openai is None:
+        raise RuntimeError("openai package not installed")
+
+    result = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return result.choices[0].message["content"].strip()
+
+
+def main(argv: List[str] | None = None) -> None:
+    load_dotenv()
+
+    parser = argparse.ArgumentParser(description="Interact with the Codex API")
+    parser.add_argument("prompt", nargs="+", help="Prompt to send to Codex")
+    parser.add_argument(
+        "--model",
+        default="gpt-4",
+        help="Model name to use with the OpenAI Chat Completions API",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the prompt without sending a request",
+    )
+
+    args = parser.parse_args(argv)
+    prompt = " ".join(args.prompt)
+
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("OPENAI_API_KEY environment variable is not set")
+
+    if args.dry_run:
+        print(prompt)
+        return
+
+    openai.api_key = api_key
+    try:
+        output = _create_completion(prompt, args.model)
+    except Exception as exc:  # pragma: no cover - network dependent
+        raise SystemExit(f"Failed to call OpenAI API: {exc}") from exc
+
+    print(output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- create a simple Python CLI under `codex_cli/`
- document usage and quickstart in package README
- mention the new CLI in the repository README

## Testing
- `python -m codex_cli --help`

------
https://chatgpt.com/codex/tasks/task_e_685b9543ad188324b1210d618e1357be